### PR TITLE
mediaChart VictoryLegend x 위치 변경/ mainWrapper에 width 추가

### DIFF
--- a/src/components/Layout/style.module.scss
+++ b/src/components/Layout/style.module.scss
@@ -8,6 +8,7 @@
   box-shadow: 1px 1px 5px rgba(0, 0, 0, 10%);
 
   .mainWrapper {
+    width: calc(100vw - 320px);
     background-color: colors.$BG_G;
 
     .pageWrapper {

--- a/src/pages/dashboard/_components/MediaStatus/MediaChart.tsx
+++ b/src/pages/dashboard/_components/MediaStatus/MediaChart.tsx
@@ -82,7 +82,7 @@ const MediaChart = () => {
 
       <VictoryStack colorScale={colorMap}>{bars}</VictoryStack>
       <VictoryLegend
-        x={643}
+        x={600}
         y={250}
         gutter={40}
         orientation="horizontal"


### PR DESCRIPTION
mediaChart VictoryLegend에서 카카오가 제대로 표시되지 않는 현상이 있어 위치를 조정했습니다.
너비 변경이 가능하도록 mainWrapper에 width를 추가했습니다.